### PR TITLE
[codex] Fix Google logout session cleanup

### DIFF
--- a/PeatedCore/Sources/PeatedCore/Services/AuthenticationManager.swift
+++ b/PeatedCore/Sources/PeatedCore/Services/AuthenticationManager.swift
@@ -18,6 +18,8 @@ public final class AuthenticationManager: ObservableObject, @unchecked Sendable 
   private let apiClient: APIClient
   private let keychain = KeychainService.shared
   private let userRepository: UserRepository
+  private let deleteStoredToken: @Sendable () throws -> Void
+  private let googleSignOut: @Sendable () -> Void
   
   public var isAuthenticated: Bool {
     if case .authenticated = authState {
@@ -33,9 +35,19 @@ public final class AuthenticationManager: ObservableObject, @unchecked Sendable 
     return nil
   }
   
-  public init() {
-    self.apiClient = APIClient.shared
+  public init(
+    apiClient: APIClient = .shared,
+    deleteStoredToken: @escaping @Sendable () throws -> Void = {
+      try KeychainService.shared.deleteToken()
+    },
+    googleSignOut: @escaping @Sendable () -> Void = {
+      GIDSignIn.sharedInstance.signOut()
+    }
+  ) {
+    self.apiClient = apiClient
     self.userRepository = UserRepository(apiClient: apiClient)
+    self.deleteStoredToken = deleteStoredToken
+    self.googleSignOut = googleSignOut
   }
   
   // MARK: - Public Methods
@@ -232,14 +244,19 @@ public final class AuthenticationManager: ObservableObject, @unchecked Sendable 
   public func logout() async {
     isLoading = true
     error = nil
-    
+
+    var logoutError: Error?
+
     do {
-      try keychain.deleteToken()
-      authState = .unauthenticated
+      try deleteStoredToken()
     } catch {
-      self.error = error
+      logoutError = error
     }
-    
+
+    googleSignOut()
+    needsTermsAcceptance = false
+    authState = .unauthenticated
+    error = logoutError
     isLoading = false
   }
   

--- a/PeatedCore/Tests/PeatedCoreTests/AuthenticationManagerTests.swift
+++ b/PeatedCore/Tests/PeatedCoreTests/AuthenticationManagerTests.swift
@@ -1,0 +1,65 @@
+import Testing
+@testable import PeatedCore
+
+struct AuthenticationManagerTests {
+  @Test
+  func logoutSignsOutGoogleAndClearsLocalState() async throws {
+    let signOutSpy = SignOutSpy()
+    let manager = AuthenticationManager(
+      apiClient: APIClient(serverURL: try #require(URL(string: "https://api.peated.com/v1"))),
+      deleteStoredToken: {},
+      googleSignOut: {
+        signOutSpy.callCount += 1
+      }
+    )
+
+    manager.needsTermsAcceptance = true
+    manager.error = LogoutFailure()
+
+    await manager.logout()
+
+    #expect(signOutSpy.callCount == 1)
+    #expect(manager.authState == .unauthenticated)
+    #expect(manager.needsTermsAcceptance == false)
+    #expect(manager.isLoading == false)
+
+    if manager.error != nil {
+      Issue.record("Expected logout to clear any previous error state")
+    }
+  }
+
+  @Test
+  func logoutStillSignsOutGoogleWhenTokenDeletionFails() async throws {
+    let signOutSpy = SignOutSpy()
+    let manager = AuthenticationManager(
+      apiClient: APIClient(serverURL: try #require(URL(string: "https://api.peated.com/v1"))),
+      deleteStoredToken: {
+        throw LogoutFailure()
+      },
+      googleSignOut: {
+        signOutSpy.callCount += 1
+      }
+    )
+
+    manager.needsTermsAcceptance = true
+
+    await manager.logout()
+
+    #expect(signOutSpy.callCount == 1)
+    #expect(manager.authState == .unauthenticated)
+    #expect(manager.needsTermsAcceptance == false)
+    #expect(manager.isLoading == false)
+
+    if let error = manager.error {
+      #expect(error is LogoutFailure)
+    } else {
+      Issue.record("Expected logout to surface the token deletion error")
+    }
+  }
+}
+
+private final class SignOutSpy: @unchecked Sendable {
+  var callCount = 0
+}
+
+private struct LogoutFailure: Error {}


### PR DESCRIPTION
## Summary
- clear the persisted Google sign-in session during logout so a logged-out user is not silently restored on next launch
- reset local logout state consistently even when token deletion fails
- add regression tests around the logout cleanup path in `AuthenticationManager`

## Why
`checkAuthStatus()` attempts `restorePreviousSignIn()` when no API token exists, but `logout()` only deleted the stored token. For Google-authenticated users, that left a restorable Google session behind after sign-out.

## Impact
Users who log out of Google-backed sessions should now remain logged out across app relaunches. The logout cleanup behavior is also covered by targeted package tests.

## Validation
- started `swift test` in `PeatedCore` outside the sandbox; dependency build began successfully
- full test completion and app-level verification were not completed because I switched to opening a draft PR at the user's request
